### PR TITLE
Add Scribe-i18n to the full architecture diagram

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,6 +25,9 @@ The following diagram represents the relationships between the Scribe projects a
         ADR([Scribe-Android])
         DSK([Scribe-Desktop])
 
+        %% Client dependencies
+        I18N((Scribe-i18n))
+
         %% Scribe data/service
         API{{Scribe-Server API}}
         DBS[(Scribe-Server DB)]
@@ -52,6 +55,7 @@ The following diagram represents the relationships between the Scribe projects a
         %%%%
         %% DATA FLOW
 
+        I18N --->|Provides Localization Data| IOS & ADR & DSK
         API --->|Client requests data| IOS & ADR & DSK
         DBS --->|API queries for data| API
         DAT --->|Job loads data| DBS

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,7 @@ The following diagram represents the relationships between the Scribe projects a
         %%%%
         %% DATA FLOW
 
-        I18N --->|Provides Localization Data| IOS & ADR & DSK
+        I18N --->|Provides localization data| IOS & ADR & DSK
         API --->|Client requests data| IOS & ADR & DSK
         DBS --->|API queries for data| API
         DAT --->|Job loads data| DBS


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
Adds Scribe-i18n as a localization file dependency for Scribe-iOS, Scribe-Android and Scribe-Desktop to the full architecture diagram.