### PR TITLE
Add Github action for posting dev sync meeting info

### DIFF
--- a/.github/workflows/matrix_dev_sync_reminder.yml
+++ b/.github/workflows/matrix_dev_sync_reminder.yml
@@ -63,6 +63,80 @@ jobs:
           echo "Next bi-weekly date: ${{ needs.weekindex.outputs.next_bi_weekly_date }}" >> $GITHUB_STEP_SUMMARY
           echo "Next EPOCH time (for sync): $next_epoch_time" >> $GITHUB_STEP_SUMMARY
 
+      - name: Etherpad Creation
+        env:
+            NEXT_BI_WEEKLY_DATE: ${{ env.NEXT_BI_WEEKLY_DATE }}
+            NEXT_EPOCH_TIME: ${{ env.NEXT_EPOCH_TIME }}
+        run: |
+                pip install requests
+                python - <<EOF
+                import requests
+                import os
+            
+                next_epoch_time = os.environ.get('NEXT_EPOCH_TIME')
+                next_bi_weekly_date = os.environ.get('NEXT_BI_WEEKLY_DATE')
+            
+                pad_name = f'scribe-dev-sync-{next_bi_weekly_date}'
+                url = f'https://etherpad.wikimedia.org/p/{pad_name}/import'
+                print(f"Importing content to: https://etherpad.wikimedia.org/p/{pad_name}")
+            
+                # The text you want to add to the pad
+                content = f"""<html><body>
+                <h1>Scribe Dev Sync {next_bi_weekly_date}</h1>
+            
+                <p>Pad directory: <a href="https://etherpad.wikimedia.org/p/scribe-dev-sync">https://etherpad.wikimedia.org/p/scribe-dev-sync</a><br>
+                ZoneStamp: <a href="https://zonestamp.toolforge.org/{next_epoch_time}">https://zonestamp.toolforge.org/{next_epoch_time}</a></p>
+            
+                <h2>Participants (please list yourself if you'd like to)</h2>
+                <ul>
+                  <li>Participant</li>
+                </ul>
+            
+                <h2>Topics</h2>
+                <ul>
+                  <li>All: introductions 👋</li>
+                  <li>All: does anyone want a calendar invite to the dev sync? If so, send them out :)</li>
+                  <li>Recap done by: NAME</li>
+                  <li>Go through the project board: <a href="https://github.com/orgs/scribe-org/projects/1">Project Board</a></li>
+                  <li>Name:</li>
+                </ul>
+            
+                <h2>Tasks (strikethrough ^/⌘ + 5 to mark as complete)</h2>
+                <ul>
+                  <li>Task</li>
+                </ul>
+            
+                <h2>Recap</h2>
+            
+                <p>Here's the recap for today's/Saturday's dev sync 🧑‍💻♻️</p>
+            
+                <ul>
+                  <li><a href="https://etherpad.wikimedia.org/p/scribe-dev-sync-{next_bi_weekly_date}">Pad for this week</a></li>
+                  <li>Note</li>
+                </ul>
+            
+                <p>The next dev sync will be <a href="https://zonestamp.toolforge.org/{next_epoch_time}">Saturday {next_bi_weekly_date} at 15:00 UTC</a>.</p>
+            
+                <p>Nice outro 😊</p>
+            
+                </body></html>"""
+            
+                # Prepare the file to upload
+                files = {
+                    'file': ('import.html', content.encode('utf-8'), 'text/html'),
+                }
+            
+                response = requests.post(url, files=files)
+            
+                if response.status_code in [200, 302]:
+                    print(f"Content imported successfully into pad '{pad_name}'.")
+                elif response.status_code == 413:
+                    print("The file is too large to upload.")
+                else:
+                    print(f"Failed to import content. Status code: {response.status_code}")
+                    print(response.text)
+                EOF
+
       - name: Send Message to Matrix Channel
         id: matrix-chat-message
         uses: fadenb/matrix-chat-message@v0.0.6
@@ -84,3 +158,4 @@ jobs:
             Please reply in the thread for this message with anything you'd like to discuss 🧵
 
             Thanks and have a great day! 💙
+            

--- a/.github/workflows/matrix_dev_sync_reminder.yml
+++ b/.github/workflows/matrix_dev_sync_reminder.yml
@@ -25,7 +25,7 @@ jobs:
           weekdiff=$(((end - start) / 60 / 60 / 24 / 7))
           weekindex=$((weekdiff % 2))
 
-          # Calculate next bi-weekly date
+          # Calculate next bi-weekly date.
           if [ "$weekindex" -eq 0 ]; then
             next_bi_weekly_date=$(date -d "$current_date + 14 days" +%Y-%m-%d)
             next_next_bi_weekly_date=$(date -d "$current_date + 28 days" +%Y-%m-%d)
@@ -74,95 +74,94 @@ jobs:
           echo "Next next bi-weekly date: ${{ needs.weekindex.outputs.next_next_bi_weekly_date }}" >> $GITHUB_STEP_SUMMARY
           echo "Next next EPOCH time (for sync): $next_next_epoch_time" >> $GITHUB_STEP_SUMMARY
 
-
       - name: Etherpad Creation
         env:
-            NEXT_BI_WEEKLY_DATE: ${{ env.NEXT_BI_WEEKLY_DATE }}
-            NEXT_EPOCH_TIME: ${{ env.NEXT_EPOCH_TIME }}
-            NEXT_NEXT_BI_WEEKLY_DATE: ${{ env.NEXT_NEXT_BI_WEEKLY_DATE }}
-            NEXT_NEXT_EPOCH_TIME: ${{ env.NEXT_NEXT_EPOCH_TIME }}
+          NEXT_BI_WEEKLY_DATE: ${{ env.NEXT_BI_WEEKLY_DATE }}
+          NEXT_EPOCH_TIME: ${{ env.NEXT_EPOCH_TIME }}
+          NEXT_NEXT_BI_WEEKLY_DATE: ${{ env.NEXT_NEXT_BI_WEEKLY_DATE }}
+          NEXT_NEXT_EPOCH_TIME: ${{ env.NEXT_NEXT_EPOCH_TIME }}
         run: |
-              pip install requests
-              python - <<EOF
-              import requests
-              import os
-          
-              next_epoch_time = os.environ.get('NEXT_EPOCH_TIME')
-              next_bi_weekly_date = os.environ.get('NEXT_BI_WEEKLY_DATE')
-              next_next_epoch_time = os.environ.get('NEXT_NEXT_EPOCH_TIME')
-              next_next_bi_weekly_date = os.environ.get('NEXT_NEXT_BI_WEEKLY_DATE')
+          pip install requests
+          python - <<EOF
+          import requests
+          import os
 
-              pad_name = f'scribe-dev-sync-{next_bi_weekly_date}'
-              url = f'https://etherpad.wikimedia.org/p/{pad_name}/import'
-              print(f"Importing content to: https://etherpad.wikimedia.org/p/{pad_name}")
-          
-              # The text you want to add to the pad
-              content = f"""<html><body>
-              <h1>Scribe Dev Sync {next_bi_weekly_date}</h1>
-          
-              <p>Pad directory:  https://etherpad.wikimedia.org/p/scribe-dev-sync</a><br>
-              ZoneStamp:  https://zonestamp.toolforge.org/{next_epoch_time}</a></p>
-              <br> <!-- Added space -->
-          
-              <h2>Participants (please list yourself if you'd like to)</h2>
-              <ul>
-                <li>Participant</li>
-              </ul>
-              <br> <!-- Added space -->
-          
-              <h2>Topics</h2>
-              <ul>
-                <li>All: introductions 👋</li>
-                <li>All: does anyone want a calendar invite to the dev sync? If so, send them out :)
-                    <ul>
-                        <li>If you would like an invite, please message Andrew on Matrix/Element</li>
-                    </ul>
-                  </li>
-                <li>Recap done by: NAME</li>
-                <li>Go through the [project board](https://github.com/orgs/scribe-org/projects/1)</a></li>
-                <li>Name:</li>
-              </ul>
-              <br> <!-- Added space -->
-          
-              <h2>Tasks (strikethrough ^/⌘ + 5 to mark as complete)</h2>
-              <ul>
-                <li>Task</li>
-              </ul>
-              <br> <!-- Added space -->
-          
-              <h2>Recap</h2>
-              <br> <!-- Added space -->
-              <br> <!-- Added space -->
-              <p>Here's the recap for today's/Saturday's dev sync 🧑‍💻♻️</p>
-          
-              <ul>
-                <li>[Pad for this week](https://etherpad.wikimedia.org/p/scribe-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }}) </a></li>
-                <li>Note</li>
-              </ul>
-              <br> <!-- Added space -->
-          
-                  <p>The next dev sync will be [Saturday the {next_next_bi_weekly_date} at 15:00 UTC](https://zonestamp.toolforge.org/{next_next_epoch_time}) </a>.</p>
-            
-              <br> <!-- Added space -->
-              <p>Nice outro 😊</p>
-          
-              </body></html>"""
-          
-              # Prepare the file to upload
-              files = {
-                  'file': ('import.html', content.encode('utf-8'), 'text/html'),
-              }
-          
-              response = requests.post(url, files=files)
-          
-              if response.status_code in [200, 302]:
-                  print(f"Content imported successfully into pad '{pad_name}'.")
-              elif response.status_code == 413:
-                  print("The file is too large to upload.")
-              else:
-                  print(f"Failed to import content. Status code: {response.status_code}")
-                  print(response.text)
-              EOF
+          next_epoch_time = os.environ.get('NEXT_EPOCH_TIME')
+          next_bi_weekly_date = os.environ.get('NEXT_BI_WEEKLY_DATE')
+          next_next_epoch_time = os.environ.get('NEXT_NEXT_EPOCH_TIME')
+          next_next_bi_weekly_date = os.environ.get('NEXT_NEXT_BI_WEEKLY_DATE')
+
+          pad_name = f'scribe-dev-sync-{next_bi_weekly_date}'
+          url = f'https://etherpad.wikimedia.org/p/{pad_name}/import'
+          print(f"Importing content to: https://etherpad.wikimedia.org/p/{pad_name}")
+
+          # The text you want to add to the pad.
+          content = f"""<html><body>
+          <h1>Scribe Dev Sync {next_bi_weekly_date}</h1>
+
+          <p>Pad directory:  https://etherpad.wikimedia.org/p/scribe-dev-sync</a><br>
+          ZoneStamp:  https://zonestamp.toolforge.org/{next_epoch_time}</a></p>
+          <br>
+
+          <h2>Participants (please list yourself if you'd like to)</h2>
+          <ul>
+            <li>Participant</li>
+          </ul>
+          <br>
+
+          <h2>Topics</h2>
+          <ul>
+            <li>All: introductions 👋</li>
+            <li>All: does anyone want a calendar invite to the dev sync? If so, send them out :)
+                <ul>
+                    <li>If you would like an invite, please message the team on Matrix/Element</li>
+                </ul>
+              </li>
+            <li>Recap done by: NAME</li>
+            <li>Go through the [project board](https://github.com/orgs/scribe-org/projects/1)</a></li>
+            <li>Name:</li>
+          </ul>
+          <br>
+
+          <h2>Tasks (strikethrough ^/⌘ + 5 to mark as complete)</h2>
+          <ul>
+            <li>Task</li>
+          </ul>
+          <br>
+
+          <h2>Recap</h2>
+          <br>
+          <br>
+          <p>Here's the recap for today's/Saturday's dev sync 🧑‍💻♻️</p>
+
+          <ul>
+            <li>[Pad for this week](https://etherpad.wikimedia.org/p/scribe-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }}) </a></li>
+            <li>Note</li>
+          </ul>
+          <br>
+
+              <p>The next dev sync will be [Saturday the {next_next_bi_weekly_date} at 15:00 UTC](https://zonestamp.toolforge.org/{next_next_epoch_time})</a>.</p>
+
+          <br>
+          <p>Nice outro 😊</p>
+
+          </body></html>"""
+
+          # Prepare the file to upload.
+          files = {
+              'file': ('import.html', content.encode('utf-8'), 'text/html'),
+          }
+
+          response = requests.post(url, files=files)
+
+          if response.status_code in [200, 302]:
+              print(f"Content imported successfully into pad '{pad_name}'.")
+          elif response.status_code == 413:
+              print("The file is too large to upload.")
+          else:
+              print(f"Failed to import content. Status code: {response.status_code}")
+              print(response.text)
+          EOF
 
       - name: Send Message to Matrix Channel
         id: matrix-chat-message
@@ -174,7 +173,7 @@ jobs:
           message: |
             Hello all! 🤖👋 Here's the reminder for [this Saturday's dev sync at 15:00 UTC](https://zonestamp.toolforge.org/${{ env.NEXT_EPOCH_TIME }}) 🧑‍💻♻️
 
-            For those new to the community, every two Saturdays the Scribe team does a call to discuss the projects. We use [Element Call](https://call.element.io/) and will also use a [pad from Wikimedia's Etherpad instance](https://etherpad.wikimedia.org/) for taking notes. Note that Element Call doesn't have a chat, so questions need to be written in the pad :)
+            For those new to the community, every two Saturdays the Scribe team does a call to discuss the projects. We use [Element Call](https://call.element.io/) and will also use a [pad from Wikimedia's Etherpad instance](https://etherpad.wikimedia.org/p/scribe-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }}) for taking notes. Note that Element Call doesn't have a chat, so questions need to be written in the pad :)
 
             Details for the upcoming sync:
 
@@ -185,4 +184,3 @@ jobs:
             Please reply in the thread for this message with anything you'd like to discuss 🧵
 
             Thanks and have a great day! 💙
-            

--- a/.github/workflows/matrix_dev_sync_reminder.yml
+++ b/.github/workflows/matrix_dev_sync_reminder.yml
@@ -115,11 +115,11 @@ jobs:
                 <li>All: introductions 👋</li>
                 <li>All: does anyone want a calendar invite to the dev sync? If so, send them out :)
                     <ul>
-                        <li>If you would like an invite, please message [Andrew]https://app.element.io/#/room/!ximYdSmPcYHLkbsbha:matrix.org on Matrix/Element</li>
+                        <li>If you would like an invite, please message Andrew on Matrix/Element</li>
                     </ul>
                   </li>
                 <li>Recap done by: NAME</li>
-                <li>Go through the project board: https://github.com/orgs/scribe-org/projects/1</a></li>
+                <li>Go through the [project board](https://github.com/orgs/scribe-org/projects/1)</a></li>
                 <li>Name:</li>
               </ul>
               <br> <!-- Added space -->
@@ -132,15 +132,16 @@ jobs:
           
               <h2>Recap</h2>
               <br> <!-- Added space -->
+              <br> <!-- Added space -->
               <p>Here's the recap for today's/Saturday's dev sync 🧑‍💻♻️</p>
           
               <ul>
-                <li>[Pad for this week] https://etherpad.wikimedia.org/p/scribe-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }} </a></li>
+                <li>[Pad for this week](https://etherpad.wikimedia.org/p/scribe-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }}) </a></li>
                 <li>Note</li>
               </ul>
               <br> <!-- Added space -->
           
-                  <p>The next dev sync will be [Saturday the {next_next_bi_weekly_date} at 15:00 UTC] https://zonestamp.toolforge.org/{next_next_epoch_time} </a>.</p>
+                  <p>The next dev sync will be [Saturday the {next_next_bi_weekly_date} at 15:00 UTC](https://zonestamp.toolforge.org/{next_next_epoch_time}) </a>.</p>
             
               <br> <!-- Added space -->
               <p>Nice outro 😊</p>

--- a/.github/workflows/matrix_dev_sync_reminder.yml
+++ b/.github/workflows/matrix_dev_sync_reminder.yml
@@ -13,6 +13,8 @@ jobs:
     outputs:
       weekindex: ${{ steps.calculate.outputs.weekindex }}
       next_bi_weekly_date: ${{ steps.calculate.outputs.next_bi_weekly_date }}
+      next_next_bi_weekly_date: ${{ steps.calculate.outputs.next_next_bi_weekly_date }}
+
     steps:
       - name: Calculate Next Date
         id: calculate
@@ -26,12 +28,17 @@ jobs:
           # Calculate next bi-weekly date
           if [ "$weekindex" -eq 0 ]; then
             next_bi_weekly_date=$(date -d "$current_date + 14 days" +%Y-%m-%d)
+            next_next_bi_weekly_date=$(date -d "$current_date + 28 days" +%Y-%m-%d)
+
           else
             next_bi_weekly_date=$(date -d "$current_date + 7 days" +%Y-%m-%d)
+            next_next_bi_weekly_date=$(date -d "$current_date + 21 days" +%Y-%m-%d)
           fi
 
           echo "weekindex=$weekindex" >> "$GITHUB_OUTPUT"
           echo "next_bi_weekly_date=$next_bi_weekly_date" >> "$GITHUB_OUTPUT"
+          echo "next_next_bi_weekly_date=$next_next_bi_weekly_date" >> "$GITHUB_OUTPUT"
+
 
           echo "FIRST_RUN_DATE: ${{ env.FIRST_RUN_DATE }}" >> $GITHUB_STEP_SUMMARY
           echo "current_date: $current_date" >> $GITHUB_STEP_SUMMARY
@@ -58,84 +65,103 @@ jobs:
           echo "EPOCH_TIME=$current_epoch_time" >> $GITHUB_ENV
           echo "NEXT_BI_WEEKLY_DATE=${{ needs.weekindex.outputs.next_bi_weekly_date }}" >> $GITHUB_ENV
           echo "NEXT_EPOCH_TIME=$next_epoch_time" >> $GITHUB_ENV
+          echo "NEXT_NEXT_BI_WEEKLY_DATE=${{ needs.weekindex.outputs.next_next_bi_weekly_date }}" >> $GITHUB_ENV
+          echo "NEXT_NEXT_EPOCH_TIME=$next_next_epoch_time" >> $GITHUB_ENV
 
           echo "Current EPOCH time: $current_epoch_time" >> $GITHUB_STEP_SUMMARY
           echo "Next bi-weekly date: ${{ needs.weekindex.outputs.next_bi_weekly_date }}" >> $GITHUB_STEP_SUMMARY
           echo "Next EPOCH time (for sync): $next_epoch_time" >> $GITHUB_STEP_SUMMARY
+          echo "Next next bi-weekly date: ${{ needs.weekindex.outputs.next_next_bi_weekly_date }}" >> $GITHUB_STEP_SUMMARY
+          echo "Next next EPOCH time (for sync): $next_next_epoch_time" >> $GITHUB_STEP_SUMMARY
+
 
       - name: Etherpad Creation
         env:
             NEXT_BI_WEEKLY_DATE: ${{ env.NEXT_BI_WEEKLY_DATE }}
             NEXT_EPOCH_TIME: ${{ env.NEXT_EPOCH_TIME }}
+            NEXT_NEXT_BI_WEEKLY_DATE: ${{ env.NEXT_NEXT_BI_WEEKLY_DATE }}
+            NEXT_NEXT_EPOCH_TIME: ${{ env.NEXT_NEXT_EPOCH_TIME }}
         run: |
-                pip install requests
-                python - <<EOF
-                import requests
-                import os
+              pip install requests
+              python - <<EOF
+              import requests
+              import os
+          
+              next_epoch_time = os.environ.get('NEXT_EPOCH_TIME')
+              next_bi_weekly_date = os.environ.get('NEXT_BI_WEEKLY_DATE')
+              next_next_epoch_time = os.environ.get('NEXT_NEXT_EPOCH_TIME')
+              next_next_bi_weekly_date = os.environ.get('NEXT_NEXT_BI_WEEKLY_DATE')
+
+              pad_name = f'scribe-dev-sync-{next_bi_weekly_date}'
+              url = f'https://etherpad.wikimedia.org/p/{pad_name}/import'
+              print(f"Importing content to: https://etherpad.wikimedia.org/p/{pad_name}")
+          
+              # The text you want to add to the pad
+              content = f"""<html><body>
+              <h1>Scribe Dev Sync {next_bi_weekly_date}</h1>
+          
+              <p>Pad directory:  https://etherpad.wikimedia.org/p/scribe-dev-sync</a><br>
+              ZoneStamp:  https://zonestamp.toolforge.org/{next_epoch_time}</a></p>
+              <br> <!-- Added space -->
+          
+              <h2>Participants (please list yourself if you'd like to)</h2>
+              <ul>
+                <li>Participant</li>
+              </ul>
+              <br> <!-- Added space -->
+          
+              <h2>Topics</h2>
+              <ul>
+                <li>All: introductions 👋</li>
+                <li>All: does anyone want a calendar invite to the dev sync? If so, send them out :)
+                    <ul>
+                        <li>If you would like an invite, please message [Andrew]https://app.element.io/#/room/!ximYdSmPcYHLkbsbha:matrix.org on Matrix/Element</li>
+                    </ul>
+                  </li>
+                <li>Recap done by: NAME</li>
+                <li>Go through the project board: https://github.com/orgs/scribe-org/projects/1</a></li>
+                <li>Name:</li>
+              </ul>
+              <br> <!-- Added space -->
+          
+              <h2>Tasks (strikethrough ^/⌘ + 5 to mark as complete)</h2>
+              <ul>
+                <li>Task</li>
+              </ul>
+              <br> <!-- Added space -->
+          
+              <h2>Recap</h2>
+              <br> <!-- Added space -->
+              <p>Here's the recap for today's/Saturday's dev sync 🧑‍💻♻️</p>
+          
+              <ul>
+                <li>[Pad for this week] https://etherpad.wikimedia.org/p/scribe-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }} </a></li>
+                <li>Note</li>
+              </ul>
+              <br> <!-- Added space -->
+          
+                  <p>The next dev sync will be [Saturday the {next_next_bi_weekly_date} at 15:00 UTC] https://zonestamp.toolforge.org/{next_next_epoch_time} </a>.</p>
             
-                next_epoch_time = os.environ.get('NEXT_EPOCH_TIME')
-                next_bi_weekly_date = os.environ.get('NEXT_BI_WEEKLY_DATE')
-            
-                pad_name = f'scribe-dev-sync-{next_bi_weekly_date}'
-                url = f'https://etherpad.wikimedia.org/p/{pad_name}/import'
-                print(f"Importing content to: https://etherpad.wikimedia.org/p/{pad_name}")
-            
-                # The text you want to add to the pad
-                content = f"""<html><body>
-                <h1>Scribe Dev Sync {next_bi_weekly_date}</h1>
-            
-                <p>Pad directory: <a href="https://etherpad.wikimedia.org/p/scribe-dev-sync">https://etherpad.wikimedia.org/p/scribe-dev-sync</a><br>
-                ZoneStamp: <a href="https://zonestamp.toolforge.org/{next_epoch_time}">https://zonestamp.toolforge.org/{next_epoch_time}</a></p>
-            
-                <h2>Participants (please list yourself if you'd like to)</h2>
-                <ul>
-                  <li>Participant</li>
-                </ul>
-            
-                <h2>Topics</h2>
-                <ul>
-                  <li>All: introductions 👋</li>
-                  <li>All: does anyone want a calendar invite to the dev sync? If so, send them out :)</li>
-                  <li>Recap done by: NAME</li>
-                  <li>Go through the project board: <a href="https://github.com/orgs/scribe-org/projects/1">Project Board</a></li>
-                  <li>Name:</li>
-                </ul>
-            
-                <h2>Tasks (strikethrough ^/⌘ + 5 to mark as complete)</h2>
-                <ul>
-                  <li>Task</li>
-                </ul>
-            
-                <h2>Recap</h2>
-            
-                <p>Here's the recap for today's/Saturday's dev sync 🧑‍💻♻️</p>
-            
-                <ul>
-                  <li><a href="https://etherpad.wikimedia.org/p/scribe-dev-sync-{next_bi_weekly_date}">Pad for this week</a></li>
-                  <li>Note</li>
-                </ul>
-            
-                <p>The next dev sync will be <a href="https://zonestamp.toolforge.org/{next_epoch_time}">Saturday {next_bi_weekly_date} at 15:00 UTC</a>.</p>
-            
-                <p>Nice outro 😊</p>
-            
-                </body></html>"""
-            
-                # Prepare the file to upload
-                files = {
-                    'file': ('import.html', content.encode('utf-8'), 'text/html'),
-                }
-            
-                response = requests.post(url, files=files)
-            
-                if response.status_code in [200, 302]:
-                    print(f"Content imported successfully into pad '{pad_name}'.")
-                elif response.status_code == 413:
-                    print("The file is too large to upload.")
-                else:
-                    print(f"Failed to import content. Status code: {response.status_code}")
-                    print(response.text)
-                EOF
+              <br> <!-- Added space -->
+              <p>Nice outro 😊</p>
+          
+              </body></html>"""
+          
+              # Prepare the file to upload
+              files = {
+                  'file': ('import.html', content.encode('utf-8'), 'text/html'),
+              }
+          
+              response = requests.post(url, files=files)
+          
+              if response.status_code in [200, 302]:
+                  print(f"Content imported successfully into pad '{pad_name}'.")
+              elif response.status_code == 413:
+                  print("The file is too large to upload.")
+              else:
+                  print(f"Failed to import content. Status code: {response.status_code}")
+                  print(response.text)
+              EOF
 
       - name: Send Message to Matrix Channel
         id: matrix-chat-message

--- a/.github/workflows/matrix_dev_sync_reminder.yml
+++ b/.github/workflows/matrix_dev_sync_reminder.yml
@@ -1,12 +1,11 @@
-name: Notify Matrix Channel of Test Message
-
+name: matrix_dev_sync_reminder
 on:
   schedule:
-    - cron: '0 14 * * 3'  # Every Wednesday at 14:00 UTC 
-  workflow_dispatch:  # Allows manual triggering
+    - cron: "0 14 * * 3" # Wednesdays at 14:00 UTC
+  workflow_dispatch: # manual triggering
 
 env:
-  FIRST_RUN_DATE: "2024-10-02"  # Set the first Wednesday you want this to run
+  FIRST_RUN_DATE: "2024-10-02"
 
 jobs:
   weekindex:
@@ -15,7 +14,7 @@ jobs:
       weekindex: ${{ steps.calculate.outputs.weekindex }}
       next_bi_weekly_date: ${{ steps.calculate.outputs.next_bi_weekly_date }}
     steps:
-      - name: Calculate week difference and next bi-weekly date
+      - name: Calculate Next Date
         id: calculate
         run: |
           current_date=$(date +%Y-%m-%d)
@@ -40,9 +39,9 @@ jobs:
           echo "weekindex: $weekindex" >> $GITHUB_STEP_SUMMARY
           echo "next_bi_weekly_date: $next_bi_weekly_date" >> $GITHUB_STEP_SUMMARY
           if [ "$weekindex" -eq 0 ]; then
-            echo "🟢 It's the first week of the bi-weekly cycle. The action is going to run." >> $GITHUB_STEP_SUMMARY
+            echo "🟢 It's the first week of the bi-weekly cycle. The action will run." >> $GITHUB_STEP_SUMMARY
           else
-            echo "🔴 It's the second week of the bi-weekly cycle. The action is going to be skipped." >> $GITHUB_STEP_SUMMARY
+            echo "🔴 It's the second week of the bi-weekly cycle. The action will be skipped." >> $GITHUB_STEP_SUMMARY
           fi
 
   send-message:
@@ -51,7 +50,7 @@ jobs:
     needs:
       - weekindex
     steps:
-      - name: Format EPOCH time
+      - name: Format EPOCH Time
         id: epoch-time
         run: |
           current_epoch_time=$(date +%s)
@@ -64,21 +63,21 @@ jobs:
           echo "Next bi-weekly date: ${{ needs.weekindex.outputs.next_bi_weekly_date }}" >> $GITHUB_STEP_SUMMARY
           echo "Next EPOCH time (for sync): $next_epoch_time" >> $GITHUB_STEP_SUMMARY
 
-      - name: Send message to Matrix channel
+      - name: Send Message to Matrix Channel
         id: matrix-chat-message
         uses: fadenb/matrix-chat-message@v0.0.6
         with:
-          homeserver: 'matrix.org'
+          homeserver: "matrix.org"
           token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
           channel: ${{ secrets.MATRIX_ROOM_ID }}
           message: |
-            Hey all! 🤖👋 Here's the reminder for [this Saturday's dev sync at 15:00 UTC](https://zonestamp.toolforge.org/${{ env.NEXT_EPOCH_TIME }}) 🤝♻️
+            Hey all! 🤖👋 Here's the reminder for [this Saturday's dev sync at 15:00 UTC](https://zonestamp.toolforge.org/${{ env.NEXT_EPOCH_TIME }}) 🧑‍💻♻️
 
             Details for it::
-            - Call link: https://call.element.io/room/#/activist-dev-sync?roomId=!UddhHUSXxHAoAnImXb:call.ems.host&password=ASriEQCG4DE6Q1QSB313zig0bhLd62RN
-            - This week’s pad: https://etherpad.wikimedia.org/p/activist-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }}
-            - All pads: https://etherpad.wikimedia.org/p/activist-dev-sync
+            - Call link: https://call.element.io/room/#/scribe-dev-sync?roomId=!UddhHUSXxHAoAnImXb:call.ems.host&password=ASriEQCG4DE6Q1QSB313zig0bhLd62RN
+            - This week's pad: https://etherpad.wikimedia.org/p/scribe-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }}
+            - All pads: https://etherpad.wikimedia.org/p/scribe-dev-sync
 
-            Please reply with anything you'd like to discuss 🧕🏼‍♀️
+            Please reply in the thread for this message with anything you'd like to discuss 🧵
 
-            Thanks and have a great day! ❤️
+            Thanks and have a great day! 💙

--- a/.github/workflows/matrix_dev_sync_reminder.yml
+++ b/.github/workflows/matrix_dev_sync_reminder.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: # manual triggering
 
 env:
-  FIRST_RUN_DATE: "2024-10-02"
+  FIRST_RUN_DATE: "2024-11-13"
 
 jobs:
   weekindex:
@@ -68,15 +68,18 @@ jobs:
         uses: fadenb/matrix-chat-message@v0.0.6
         with:
           homeserver: "matrix.org"
-          token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          channel: ${{ secrets.MATRIX_ROOM_ID }}
+          token: ${{ secrets.MATRIX_SCRIBE_BOT_ACCESS_TOKEN }}
+          channel: ${{ secrets.MATRIX_GENERAL_ROOM_ID }}
           message: |
-            Hey all! 🤖👋 Here's the reminder for [this Saturday's dev sync at 15:00 UTC](https://zonestamp.toolforge.org/${{ env.NEXT_EPOCH_TIME }}) 🧑‍💻♻️
+            Hello all! 🤖👋 Here's the reminder for [this Saturday's dev sync at 15:00 UTC](https://zonestamp.toolforge.org/${{ env.NEXT_EPOCH_TIME }}) 🧑‍💻♻️
 
-            Details for it::
+            For those new to the community, every two Saturdays the Scribe team does a call to discuss the projects. We use [Element Call](https://call.element.io/) and will also use a [pad from Wikimedia's Etherpad instance](https://etherpad.wikimedia.org/) for taking notes. Note that Element Call doesn't have a chat, so questions need to be written in the pad :)
+
+            Details for the upcoming sync:
+
             - Call link: https://call.element.io/room/#/scribe-dev-sync?roomId=!UddhHUSXxHAoAnImXb:call.ems.host&password=ASriEQCG4DE6Q1QSB313zig0bhLd62RN
             - This week's pad: https://etherpad.wikimedia.org/p/scribe-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }}
-            - All pads: https://etherpad.wikimedia.org/p/scribe-dev-sync
+            - All Scribe pads: https://etherpad.wikimedia.org/p/scribe-dev-sync
 
             Please reply in the thread for this message with anything you'd like to discuss 🧵
 

--- a/.github/workflows/notify_matrix.yml
+++ b/.github/workflows/notify_matrix.yml
@@ -1,0 +1,84 @@
+name: Notify Matrix Channel of Test Message
+
+on:
+  schedule:
+    - cron: '0 14 * * 3'  # Every Wednesday at 14:00 UTC 
+  workflow_dispatch:  # Allows manual triggering
+
+env:
+  FIRST_RUN_DATE: "2024-10-02"  # Set the first Wednesday you want this to run
+
+jobs:
+  weekindex:
+    runs-on: ubuntu-latest
+    outputs:
+      weekindex: ${{ steps.calculate.outputs.weekindex }}
+      next_bi_weekly_date: ${{ steps.calculate.outputs.next_bi_weekly_date }}
+    steps:
+      - name: Calculate week difference and next bi-weekly date
+        id: calculate
+        run: |
+          current_date=$(date +%Y-%m-%d)
+          start=$(date -d "${{ env.FIRST_RUN_DATE }}" +%s)
+          end=$(date -d "$current_date" +%s)
+          weekdiff=$(((end - start) / 60 / 60 / 24 / 7))
+          weekindex=$((weekdiff % 2))
+
+          # Calculate next bi-weekly date
+          if [ "$weekindex" -eq 0 ]; then
+            next_bi_weekly_date=$(date -d "$current_date + 14 days" +%Y-%m-%d)
+          else
+            next_bi_weekly_date=$(date -d "$current_date + 7 days" +%Y-%m-%d)
+          fi
+
+          echo "weekindex=$weekindex" >> "$GITHUB_OUTPUT"
+          echo "next_bi_weekly_date=$next_bi_weekly_date" >> "$GITHUB_OUTPUT"
+
+          echo "FIRST_RUN_DATE: ${{ env.FIRST_RUN_DATE }}" >> $GITHUB_STEP_SUMMARY
+          echo "current_date: $current_date" >> $GITHUB_STEP_SUMMARY
+          echo "weekdiff: $weekdiff" >> $GITHUB_STEP_SUMMARY
+          echo "weekindex: $weekindex" >> $GITHUB_STEP_SUMMARY
+          echo "next_bi_weekly_date: $next_bi_weekly_date" >> $GITHUB_STEP_SUMMARY
+          if [ "$weekindex" -eq 0 ]; then
+            echo "🟢 It's the first week of the bi-weekly cycle. The action is going to run." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "🔴 It's the second week of the bi-weekly cycle. The action is going to be skipped." >> $GITHUB_STEP_SUMMARY
+          fi
+
+  send-message:
+    if: ${{ needs.weekindex.outputs.weekindex == '0' }}
+    runs-on: ubuntu-latest
+    needs:
+      - weekindex
+    steps:
+      - name: Format EPOCH time
+        id: epoch-time
+        run: |
+          current_epoch_time=$(date +%s)
+          next_epoch_time=$(date -d "${{ needs.weekindex.outputs.next_bi_weekly_date }} 15:00:00" +%s)
+          echo "EPOCH_TIME=$current_epoch_time" >> $GITHUB_ENV
+          echo "NEXT_BI_WEEKLY_DATE=${{ needs.weekindex.outputs.next_bi_weekly_date }}" >> $GITHUB_ENV
+          echo "NEXT_EPOCH_TIME=$next_epoch_time" >> $GITHUB_ENV
+
+          echo "Current EPOCH time: $current_epoch_time" >> $GITHUB_STEP_SUMMARY
+          echo "Next bi-weekly date: ${{ needs.weekindex.outputs.next_bi_weekly_date }}" >> $GITHUB_STEP_SUMMARY
+          echo "Next EPOCH time (for sync): $next_epoch_time" >> $GITHUB_STEP_SUMMARY
+
+      - name: Send message to Matrix channel
+        id: matrix-chat-message
+        uses: fadenb/matrix-chat-message@v0.0.6
+        with:
+          homeserver: 'matrix.org'
+          token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          channel: ${{ secrets.MATRIX_ROOM_ID }}
+          message: |
+            Hey all! 🤖👋 Here's the reminder for [this Saturday's dev sync at 15:00 UTC](https://zonestamp.toolforge.org/${{ env.NEXT_EPOCH_TIME }}) 🤝♻️
+
+            Details for it::
+            - Call link: https://call.element.io/room/#/activist-dev-sync?roomId=!UddhHUSXxHAoAnImXb:call.ems.host&password=ASriEQCG4DE6Q1QSB313zig0bhLd62RN
+            - This week’s pad: https://etherpad.wikimedia.org/p/activist-dev-sync-${{ env.NEXT_BI_WEEKLY_DATE }}
+            - All pads: https://etherpad.wikimedia.org/p/activist-dev-sync
+
+            Please reply with anything you'd like to discuss 🧕🏼‍♀️
+
+            Thanks and have a great day! ❤️


### PR DESCRIPTION
Added workflow to post about dev sync meeting in Element channel automatically biweekly.

Here is the result when I ran this [workflow](https://github.com/axif0/git-workflow/actions/runs/11328070415) in my personal repo - 

![image](https://github.com/user-attachments/assets/8b0cd9d9-8f98-4360-a104-3b2da77dbf7f)

It is the test message sent in test Element channel - 

![image](https://github.com/user-attachments/assets/cf295f53-e25f-4713-a13b-83e51593b711)


**Reference** -
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
- https://medium.com/@VeselyCodes/bi-weekly-github-actions-7bea6be7bd96


**Additional support** - 
Need support from @andrewtavis - please add `MATRIX_ACCESS_TOKEN` and `MATRIX_ROOM_ID` to make this workflow run properly.

